### PR TITLE
feat: implement responsive bottom sheets for mobile modals

### DIFF
--- a/BOTTOM_SHEET_README.md
+++ b/BOTTOM_SHEET_README.md
@@ -1,0 +1,63 @@
+# Responsive Bottom Sheet Implementation
+
+## Overview
+All modals in the application now automatically display as bottom sheets on mobile devices while maintaining the traditional centered modal experience on desktop.
+
+## What was implemented
+
+### 1. Responsive Dialog Component (`src/components/ui/responsive-dialog.tsx`)
+- **Desktop**: Centered modal with zoom animations
+- **Mobile**: Bottom sheet with slide-up animations
+- **Features**:
+  - Drag indicator on mobile
+  - Safe area inset support for devices with notches
+  - Maximum height of 85vh on mobile with scrolling
+  - Smooth animations with custom CSS keyframes
+
+### 2. Updated Components
+- ✅ **QuickExpenseModal** (FAB modal)
+- ✅ **TransactionForm** (in Transactions page)
+- ✅ **CategoryForm** (in Categories page)
+
+### 3. Custom Animations
+Added to `src/index.css`:
+- `slide-in-from-bottom` - Smooth slide up animation
+- `slide-out-to-bottom` - Smooth slide down animation
+- Mobile safe area support
+
+## Usage
+
+Replace regular Dialog imports with responsive versions:
+
+```tsx
+// Before
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+// After
+import { 
+  ResponsiveDialog as Dialog, 
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle 
+} from "@/components/ui/responsive-dialog";
+```
+
+## Mobile Experience Features
+- 📱 **Bottom Sheet**: Slides up from bottom on mobile
+- 📏 **Drag Indicator**: Visual cue for users
+- 🔒 **Safe Areas**: Respects device notches and home indicators  
+- 📜 **Scrollable**: Handles long content gracefully
+- ⚡ **Smooth Animations**: Custom CSS animations for better UX
+- 🎯 **Touch Friendly**: Optimized for mobile interaction
+
+## Desktop Experience
+- 🖥️ **Centered Modal**: Traditional modal experience
+- 🎨 **Zoom Animations**: Smooth scale-in/out transitions
+- 📐 **Max Width Control**: Responsive sizing with `sm:max-w-*` classes
+
+## Testing
+To test the responsive behavior:
+1. Open the app in browser
+2. Use browser dev tools to toggle device simulation
+3. Try opening modals in different viewport sizes
+4. Test the FAB (floating action button) for quick expense entry

--- a/src/components/ui/quick-expense-modal.tsx
+++ b/src/components/ui/quick-expense-modal.tsx
@@ -3,12 +3,12 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '@/components/ui/responsive-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Calendar } from '@/components/ui/calendar';
 import {

--- a/src/components/ui/responsive-dialog.tsx
+++ b/src/components/ui/responsive-dialog.tsx
@@ -1,0 +1,135 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ResponsiveDialog = DialogPrimitive.Root;
+const ResponsiveDialogTrigger = DialogPrimitive.Trigger;
+const ResponsiveDialogPortal = DialogPrimitive.Portal;
+const ResponsiveDialogClose = DialogPrimitive.Close;
+
+const ResponsiveDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+ResponsiveDialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const ResponsiveDialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <ResponsiveDialogPortal>
+    <ResponsiveDialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        // Base styles
+        "fixed z-50 grid w-full gap-4 border bg-background p-6 shadow-lg duration-200",
+        // Desktop: centered modal
+        "sm:left-[50%] sm:top-[50%] sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg",
+        // Desktop animations
+        "sm:data-[state=open]:animate-in sm:data-[state=closed]:animate-out sm:data-[state=closed]:fade-out-0 sm:data-[state=open]:fade-in-0",
+        "sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95",
+        "sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%]",
+        "sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%]",
+        // Mobile: bottom sheet
+        "bottom-0 left-0 right-0 rounded-t-[10px] mobile-safe-bottom",
+        // Mobile animations
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:animate-slide-out-to-bottom data-[state=open]:animate-slide-in-from-bottom",
+        // Mobile specific max height and scrolling
+        "max-h-[85vh] overflow-y-auto",
+        className,
+      )}
+      {...props}
+    >
+      {/* Mobile drag indicator */}
+      <div className="mx-auto w-12 h-1.5 rounded-full bg-gray-300 dark:bg-gray-600 mb-2 sm:hidden" />
+      
+      {children}
+      
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </ResponsiveDialogPortal>
+));
+ResponsiveDialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const ResponsiveDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left pb-2",
+      className,
+    )}
+    {...props}
+  />
+);
+ResponsiveDialogHeader.displayName = "ResponsiveDialogHeader";
+
+const ResponsiveDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 pt-4 gap-2 sm:gap-0",
+      className,
+    )}
+    {...props}
+  />
+);
+ResponsiveDialogFooter.displayName = "ResponsiveDialogFooter";
+
+const ResponsiveDialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+ResponsiveDialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const ResponsiveDialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+ResponsiveDialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  ResponsiveDialog,
+  ResponsiveDialogPortal,
+  ResponsiveDialogOverlay,
+  ResponsiveDialogClose,
+  ResponsiveDialogTrigger,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogFooter,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -99,3 +99,39 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  /* Bottom sheet animations */
+  @keyframes slide-in-from-bottom {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0%);
+    }
+  }
+
+  @keyframes slide-out-to-bottom {
+    from {
+      transform: translateY(0%);
+    }
+    to {
+      transform: translateY(100%);
+    }
+  }
+
+  .animate-slide-in-from-bottom {
+    animation: slide-in-from-bottom 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  .animate-slide-out-to-bottom {
+    animation: slide-out-to-bottom 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  /* Ensure mobile bottom sheets don't go beyond viewport */
+  @media (max-width: 640px) {
+    .mobile-safe-bottom {
+      padding-bottom: env(safe-area-inset-bottom);
+    }
+  }
+}

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -2,12 +2,12 @@ import { DashboardLayout } from "@/components/layouts/DashboardLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+  ResponsiveDialogTrigger as DialogTrigger,
+} from "@/components/ui/responsive-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -200,7 +200,7 @@ const Categories: React.FC = () => {
                 Add Category
               </Button>
             </DialogTrigger>
-            <DialogContent>
+            <DialogContent className="sm:max-w-md">
               <DialogHeader>
                 <DialogTitle>
                   {editingCategory ? "Edit Category" : "Create New Category"}

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -3,7 +3,11 @@ import { TransactionForm } from "@/components/transactions/TransactionForm";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { 
+  ResponsiveDialog as Dialog, 
+  ResponsiveDialogContent as DialogContent, 
+  ResponsiveDialogTrigger as DialogTrigger 
+} from "@/components/ui/responsive-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -180,7 +184,7 @@ const Transactions: React.FC = () => {
                 Add Transaction
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+            <DialogContent className="sm:max-w-2xl">
               <TransactionForm
                 transaction={editingTransaction}
                 onSuccess={handleFormSuccess}


### PR DESCRIPTION
- Create ResponsiveDialog component that automatically switches between:
  * Desktop: centered modal with zoom animations
  * Mobile: bottom sheet with slide-up animations
- Add drag indicator and safe area support for mobile devices
- Update all major modals to use responsive bottom sheet pattern:
  * QuickExpenseModal (FAB)
  * Transaction form modal
  * Category form modal
- Add custom CSS animations for smooth mobile transitions
- Implement mobile-safe bottom padding for devices with notches
- Maintain full backward compatibility with existing dialog usage

🤖 Generated with [Claude Code](https://claude.ai/code)