### PR TITLE
refactor: migrate date picker components to shared DateSelect

### DIFF
--- a/src/components/recurring/RecurringTransactionForm/RecurrenceSettingsFields/CreateStartDateField/CreateStartDateField.tsx
+++ b/src/components/recurring/RecurringTransactionForm/RecurrenceSettingsFields/CreateStartDateField/CreateStartDateField.tsx
@@ -1,74 +1,29 @@
 import { type FC } from "react";
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { DateSelect } from "@/components/shared/DateSelect";
 import { UseFormReturn } from "react-hook-form";
-import { format } from "date-fns";
-import { CalendarIcon } from "lucide-react";
 import { RecurringTransactionCreateFormData } from "../../RecurringTransactionForm.types";
 
 type CreateStartDateFieldProps = {
   form: UseFormReturn<RecurringTransactionCreateFormData>;
-  isOpen: boolean;
-  onOpenChange: (open: boolean) => void;
 };
 
 export const CreateStartDateField: FC<CreateStartDateFieldProps> = ({
   form,
-  isOpen,
-  onOpenChange,
 }) => {
   const {
     formState: { errors },
     watch,
     setValue,
   } = form;
-  const watchStartDate = watch("startDate");
 
   return (
-    <div className="space-y-2">
-      <Label>
-        Start Date <span className="text-red-500">*</span>
-      </Label>
-      <Popover open={isOpen} onOpenChange={onOpenChange}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            className={cn(
-              "w-full justify-start text-left font-normal",
-              !watchStartDate && "text-muted-foreground",
-              errors.startDate && "border-red-500",
-            )}
-          >
-            <CalendarIcon className="mr-2 h-4 w-4" />
-            {watchStartDate ? (
-              format(watchStartDate, "PPP")
-            ) : (
-              <span>Select start date</span>
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            mode="single"
-            selected={watchStartDate}
-            onSelect={(date) => {
-              setValue("startDate", date || new Date());
-              onOpenChange(false);
-            }}
-            initialFocus
-          />
-        </PopoverContent>
-      </Popover>
-      {errors.startDate && (
-        <p className="text-sm text-red-500">{errors.startDate.message}</p>
-      )}
-    </div>
+    <DateSelect
+      value={watch("startDate")}
+      onChange={(date) => setValue("startDate", date ?? new Date())}
+      label="Start Date"
+      placeholder="Select start date"
+      error={errors.startDate?.message}
+      required
+    />
   );
 };

--- a/src/components/recurring/RecurringTransactionForm/RecurrenceSettingsFields/EndDateField/EndDateField.tsx
+++ b/src/components/recurring/RecurringTransactionForm/RecurrenceSettingsFields/EndDateField/EndDateField.tsx
@@ -1,23 +1,12 @@
 import { type FC } from "react";
 import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import { CalendarIcon } from "lucide-react";
+import { DateSelect } from "@/components/shared/DateSelect";
 
 type EndDateFieldProps = {
   watchEndDate: Date | null | undefined;
   minDate: Date;
   error?: string;
-  isOpen: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSelect: (date: Date | undefined) => void;
+  onSelect: (date: Date | null) => void;
   onClear: () => void;
 };
 
@@ -25,44 +14,18 @@ export const EndDateField: FC<EndDateFieldProps> = ({
   watchEndDate,
   minDate,
   error,
-  isOpen,
-  onOpenChange,
   onSelect,
   onClear,
 }) => (
   <div className="space-y-2">
-    <Label>End Date (optional)</Label>
-    <Popover open={isOpen} onOpenChange={onOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          className={cn(
-            "w-full justify-start text-left font-normal",
-            !watchEndDate && "text-muted-foreground",
-            error && "border-red-500",
-          )}
-        >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          {watchEndDate ? (
-            format(watchEndDate, "PPP")
-          ) : (
-            <span>Select end date...</span>
-          )}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
-        <Calendar
-          mode="single"
-          selected={watchEndDate || undefined}
-          onSelect={(date) => {
-            onSelect(date);
-            onOpenChange(false);
-          }}
-          initialFocus
-          disabled={(date) => date < minDate}
-        />
-      </PopoverContent>
-    </Popover>
+    <DateSelect
+      value={watchEndDate}
+      onChange={(date) => onSelect(date)}
+      label="End Date (optional)"
+      placeholder="Select end date..."
+      error={error}
+      disabledDates={(date) => date < minDate}
+    />
     {watchEndDate && (
       <Button
         type="button"
@@ -74,7 +37,6 @@ export const EndDateField: FC<EndDateFieldProps> = ({
         Clear end date
       </Button>
     )}
-    {error && <p className="text-sm text-red-500">{error}</p>}
     <p className="text-xs text-gray-500 dark:text-gray-400">
       Leave empty for indefinite recurrence
     </p>

--- a/src/components/recurring/RecurringTransactionForm/RecurrenceSettingsFields/RecurrenceSettingsFields.tsx
+++ b/src/components/recurring/RecurringTransactionForm/RecurrenceSettingsFields/RecurrenceSettingsFields.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from "react";
+import { type FC } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { RecurringTransaction } from "@/types";
 import { UseFormReturn } from "react-hook-form";
@@ -29,8 +29,6 @@ export const RecurrenceSettingsFields: FC<RecurrenceSettingsFieldsProps> = (
   props,
 ) => {
   const { mode, form } = props;
-  const [startCalendarOpen, setStartCalendarOpen] = useState(false);
-  const [endCalendarOpen, setEndCalendarOpen] = useState(false);
 
   // Cast to UseFormReturn<any> for shared endDate field access across both form types
   const sharedForm = form as UseFormReturn<any>;
@@ -58,11 +56,7 @@ export const RecurrenceSettingsFields: FC<RecurrenceSettingsFieldsProps> = (
         />
       )}
       {mode === "create" ? (
-        <CreateStartDateField
-          form={props.form}
-          isOpen={startCalendarOpen}
-          onOpenChange={setStartCalendarOpen}
-        />
+        <CreateStartDateField form={props.form} />
       ) : (
         <ReadOnlyField
           label="Start Date"
@@ -74,9 +68,7 @@ export const RecurrenceSettingsFields: FC<RecurrenceSettingsFieldsProps> = (
         watchEndDate={watchEndDate}
         minDate={minEndDate}
         error={errors.endDate?.message as string}
-        isOpen={endCalendarOpen}
-        onOpenChange={setEndCalendarOpen}
-        onSelect={(date) => sharedForm.setValue("endDate", date || null)}
+        onSelect={(date) => sharedForm.setValue("endDate", date)}
         onClear={() => sharedForm.setValue("endDate", null)}
       />
       <Alert>

--- a/src/components/shared/DateSelect/DateSelect.tsx
+++ b/src/components/shared/DateSelect/DateSelect.tsx
@@ -24,7 +24,7 @@ type DateSelectProps = {
 export const DateSelect: React.FC<DateSelectProps> = ({
   value,
   onChange,
-  label = "Date",
+  label,
   placeholder = "Pick a date",
   error,
   required,
@@ -34,10 +34,12 @@ export const DateSelect: React.FC<DateSelectProps> = ({
 
   return (
     <div className="space-y-2">
-      <Label>
-        {label}
-        {required && <span className="text-red-500"> *</span>}
-      </Label>
+      {label && (
+        <Label>
+          {label}
+          {required && <span className="text-red-500"> *</span>}
+        </Label>
+      )}
       <Popover open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild>
           <Button

--- a/src/components/transactions/QuickExpenseModal/QuickExpenseFields/QuickExpenseFields.tsx
+++ b/src/components/transactions/QuickExpenseModal/QuickExpenseFields/QuickExpenseFields.tsx
@@ -53,6 +53,7 @@ export const QuickExpenseFields: FC<QuickExpenseFieldsProps> = ({
         required
       />
       <DateSelect
+        label="Date"
         value={watch("date")}
         onChange={(date) => setValue("date", date ?? new Date())}
         error={errors.date?.message}

--- a/src/components/transactions/TransactionForm/BasicInfoFields/BasicInfoFields.tsx
+++ b/src/components/transactions/TransactionForm/BasicInfoFields/BasicInfoFields.tsx
@@ -59,6 +59,7 @@ export const BasicInfoFields: FC<BasicInfoFieldsProps> = ({
         />
       </div>
       <DateSelect
+        label="Date"
         value={watch("date")}
         onChange={(date) => setValue("date", date ?? new Date())}
         error={errors.date?.message}

--- a/src/components/transactions/TransactionsFilters/TransactionsFilters.tsx
+++ b/src/components/transactions/TransactionsFilters/TransactionsFilters.tsx
@@ -87,13 +87,11 @@ export const TransactionsFilters: FC<TransactionsFiltersProps> = ({
           </SelectContent>
         </Select>
         <DateSelect
-          label="Start date"
           placeholder="Start date"
           value={startDate}
           onChange={(date) => onStartDateChange(date ?? undefined)}
         />
         <DateSelect
-          label="End date"
           placeholder="End date"
           value={endDate}
           onChange={(date) => onEndDateChange(date ?? undefined)}


### PR DESCRIPTION
## Summary
- Migrated `CreateStartDateField` and `EndDateField` to use the shared `DateSelect` component, replacing inline Popover+Calendar markup
- Removed calendar open state management from `RecurrenceSettingsFields`
- Fixed filter alignment bug where DateSelect labels pushed date pickers out of alignment with other filter fields

## Test plan
- [ ] Verify recurring transaction form date pickers work correctly (start and end dates)
- [ ] Test clearing the end date button functionality
- [ ] Confirm filter alignment is correct in TransactionsFilters (no vertical misalignment)
- [ ] Check date selection in transaction form and quick expense modal
- [ ] `npm run typecheck:all` — no new type errors
- [ ] `npm run test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified date selection experience across the application with a unified, streamlined date picker interface.
  * Enhanced UI consistency in recurring transaction settings, expense entry forms, and transaction filtering.

* **Refinements**
  * Optimized date picker interactions for improved usability with consistent label handling across date input components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->