### PR TITLE
fix(quick-expense): clean up modal UI — remove upload, wire notes, fix category picker

### DIFF
--- a/src/components/recurring/RecurringTransactionForm/TransactionDetailsFields/TransactionDetailsFields.tsx
+++ b/src/components/recurring/RecurringTransactionForm/TransactionDetailsFields/TransactionDetailsFields.tsx
@@ -74,7 +74,7 @@ export const TransactionDetailsFields: FC<TransactionDetailsFieldsProps> = ({
           id="description"
           placeholder="Add a note about this recurring transaction..."
           {...register("description")}
-          className={errors.description ? "border-red-500" : ""}
+          aria-invalid={!!errors.description}
           maxLength={256}
           rows={2}
         />

--- a/src/components/transactions/QuickExpenseModal/QuickCategorySelect/QuickCategorySelect.tsx
+++ b/src/components/transactions/QuickExpenseModal/QuickCategorySelect/QuickCategorySelect.tsx
@@ -92,7 +92,7 @@ export const QuickCategorySelect: FC<QuickCategorySelectProps> = ({
         <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
           <div className="px-px pt-1">
             <Select value={selectedCategoryId ?? ""} onValueChange={handleOtherSelect}>
-              <SelectTrigger>
+              <SelectTrigger className="rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 data-[state=open]:border-b-2 data-[state=open]:border-b-gold-500 data-[state=open]:rounded-b-none focus-visible:border-b-2 focus-visible:border-b-gold-500 dark:border-b-neutral-600 dark:bg-neutral-800 dark:data-[state=open]:border-b-2 dark:data-[state=open]:border-b-gold-500 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500">
                 <SelectValue placeholder="Select a category" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/transactions/QuickExpenseModal/QuickCategorySelect/QuickCategorySelect.tsx
+++ b/src/components/transactions/QuickExpenseModal/QuickCategorySelect/QuickCategorySelect.tsx
@@ -56,6 +56,11 @@ export const QuickCategorySelect: FC<QuickCategorySelectProps> = ({
     ? categories.find((c) => c.name.toLowerCase() === selectedCategory.toLowerCase())?.id
     : undefined;
 
+  /** Quick grid already covers these names; only list remaining expense categories here */
+  const otherSelectCategories = categories.filter(
+    (cat) => !QUICK_NAMES.has(cat.name.toLowerCase()),
+  );
+
   return (
     <div className="space-y-4">
       <span className="text-overline text-neutral-500 uppercase tracking-[1.5px]">
@@ -92,11 +97,11 @@ export const QuickCategorySelect: FC<QuickCategorySelectProps> = ({
         <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
           <div className="px-px pt-1">
             <Select value={selectedCategoryId ?? ""} onValueChange={handleOtherSelect}>
-              <SelectTrigger className="rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 data-[state=open]:border-b-2 data-[state=open]:border-b-gold-500 data-[state=open]:rounded-b-none focus-visible:border-b-2 focus-visible:border-b-gold-500 dark:border-b-neutral-600 dark:bg-neutral-800 dark:data-[state=open]:border-b-2 dark:data-[state=open]:border-b-gold-500 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500">
+              <SelectTrigger variant="underlined">
                 <SelectValue placeholder="Select a category" />
               </SelectTrigger>
               <SelectContent>
-                {categories.map((cat) => (
+                {otherSelectCategories.map((cat) => (
                   <SelectItem key={cat.id} value={cat.id}>
                     {cat.name}
                   </SelectItem>

--- a/src/components/transactions/QuickExpenseModal/QuickExpenseFields/MoreOptionsSection.tsx
+++ b/src/components/transactions/QuickExpenseModal/QuickExpenseFields/MoreOptionsSection.tsx
@@ -1,5 +1,7 @@
 import { type FC } from "react";
 
+import { Textarea } from "@/components/ui/textarea";
+
 type MoreOptionsSectionProps = {
   notes: string;
   onNotesChange: (value: string) => void;
@@ -12,15 +14,15 @@ export const MoreOptionsSection: FC<MoreOptionsSectionProps> = ({
   return (
     <div className="space-y-4 pt-2">
       {/* Notes Field */}
-      <div className="space-y-2">
+      <div className="space-y-2 pb-1">
         <span className="text-overline text-neutral-500 uppercase tracking-[1.5px]">
           Notes
         </span>
-        <textarea
+        <Textarea
+          variant="underlined"
           value={notes}
           onChange={(e) => onNotesChange(e.target.value)}
           placeholder="Add any additional notes..."
-          className="w-full rounded-md bg-neutral-100 p-3 text-[16px] text-foreground placeholder:text-neutral-500 outline-none focus-visible:ring-1 focus-visible:ring-gold-500 resize-none dark:bg-neutral-800 dark:placeholder:text-neutral-500"
           rows={3}
         />
       </div>

--- a/src/components/transactions/QuickExpenseModal/QuickExpenseFields/MoreOptionsSection.tsx
+++ b/src/components/transactions/QuickExpenseModal/QuickExpenseFields/MoreOptionsSection.tsx
@@ -1,5 +1,6 @@
 import { type FC } from "react";
 
+import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
 type MoreOptionsSectionProps = {
@@ -15,10 +16,14 @@ export const MoreOptionsSection: FC<MoreOptionsSectionProps> = ({
     <div className="space-y-4 pt-2">
       {/* Notes Field */}
       <div className="space-y-2 pb-1">
-        <span className="text-overline text-neutral-500 uppercase tracking-[1.5px]">
+        <Label
+          htmlFor="notes"
+          className="text-overline text-neutral-500 uppercase tracking-[1.5px]"
+        >
           Notes
-        </span>
+        </Label>
         <Textarea
+          id="notes"
           variant="underlined"
           value={notes}
           onChange={(e) => onNotesChange(e.target.value)}

--- a/src/components/transactions/QuickExpenseModal/QuickExpenseFields/QuickExpenseFields.tsx
+++ b/src/components/transactions/QuickExpenseModal/QuickExpenseFields/QuickExpenseFields.tsx
@@ -118,7 +118,7 @@ export const QuickExpenseFields: FC<QuickExpenseFieldsProps> = ({
                 );
               }}
             >
-              <SelectTrigger className="rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 data-[state=open]:border-b-2 data-[state=open]:border-b-gold-500 data-[state=open]:rounded-b-none focus-visible:border-b-2 focus-visible:border-b-gold-500 dark:border-b-neutral-600 dark:bg-neutral-800 dark:data-[state=open]:border-b-2 dark:data-[state=open]:border-b-gold-500 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500">
+              <SelectTrigger variant="underlined">
                 <SelectValue placeholder="Select frequency" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,8 +1,26 @@
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
+import { cva, type VariantProps } from "class-variance-authority";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+
+const selectTriggerVariants = cva(
+  "flex h-10 w-full items-center justify-between px-3 py-2 text-body text-foreground data-[placeholder]:text-neutral-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-surface [&>span]:line-clamp-1",
+  {
+    variants: {
+      variant: {
+        default:
+          "rounded-sm border border-neutral-200 bg-white focus-visible:border-2 focus-visible:border-gold-500 focus-visible:px-[11px] data-[state=open]:border-2 data-[state=open]:border-gold-500 data-[state=open]:px-[11px] dark:border-neutral-700 dark:bg-neutral-800",
+        underlined:
+          "rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 data-[state=open]:rounded-b-none data-[state=open]:border-b-2 data-[state=open]:border-b-gold-500 focus-visible:border-b-2 focus-visible:border-b-gold-500 dark:border-b-neutral-600 dark:bg-neutral-800 dark:data-[state=open]:border-b-2 dark:data-[state=open]:border-b-gold-500 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
 
 const Select = SelectPrimitive.Root;
 
@@ -10,16 +28,18 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
+export type SelectTriggerProps = React.ComponentPropsWithoutRef<
+  typeof SelectPrimitive.Trigger
+> &
+  VariantProps<typeof selectTriggerVariants>;
+
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  SelectTriggerProps
+>(({ className, variant, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
-    className={cn(
-      "flex h-10 w-full items-center justify-between rounded-sm border border-neutral-200 bg-white px-3 py-2 text-body text-foreground data-[placeholder]:text-neutral-500 focus:outline-none focus-visible:border-2 focus-visible:border-gold-500 focus-visible:px-[11px] data-[state=open]:border-2 data-[state=open]:border-gold-500 data-[state=open]:px-[11px] disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-surface dark:bg-neutral-800 dark:border-neutral-700 [&>span]:line-clamp-1",
-      className,
-    )}
+    className={cn(selectTriggerVariants({ variant }), className)}
     {...props}
   >
     {children}
@@ -149,6 +169,7 @@ export {
   SelectGroup,
   SelectValue,
   SelectTrigger,
+  selectTriggerVariants,
   SelectContent,
   SelectLabel,
   SelectItem,

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,9 +9,9 @@ const textareaVariants = cva(
     variants: {
       variant: {
         default:
-          "rounded-sm border border-neutral-200 bg-white px-3 py-2.5 text-body focus-visible:outline-none focus-visible:border-2 focus-visible:border-gold-500 focus-visible:px-[11px] focus-visible:py-[9px] disabled:bg-surface aria-[invalid=true]:border-danger-500 aria-[invalid=true]:bg-danger-50 dark:bg-neutral-800 dark:border-neutral-700",
+          "rounded-sm border border-neutral-200 bg-white px-3 py-2.5 text-body focus-visible:outline-none focus-visible:border-2 focus-visible:border-gold-500 focus-visible:px-[11px] focus-visible:py-[9px] disabled:bg-surface aria-[invalid=true]:border-danger-500 aria-[invalid=true]:bg-danger-50 dark:bg-neutral-800 dark:border-neutral-700 dark:aria-[invalid=true]:bg-danger-700/20",
         underlined:
-          "rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 px-3 py-2.5 text-base outline-none focus-visible:border-b-2 focus-visible:border-b-gold-500 aria-[invalid=true]:border-b-2 aria-[invalid=true]:border-b-danger-500 aria-[invalid=true]:bg-danger-50 dark:border-b-neutral-600 dark:bg-neutral-800 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500 dark:aria-[invalid=true]:border-b-2 dark:aria-[invalid=true]:border-b-danger-500",
+          "rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 px-3 py-2.5 text-base outline-none focus-visible:border-b-2 focus-visible:border-b-gold-500 aria-[invalid=true]:border-b-2 aria-[invalid=true]:border-b-danger-500 aria-[invalid=true]:bg-danger-50 dark:border-b-neutral-600 dark:bg-neutral-800 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500 dark:aria-[invalid=true]:border-b-2 dark:aria-[invalid=true]:border-b-danger-500 dark:aria-[invalid=true]:bg-danger-700/20",
       },
     },
     defaultVariants: {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,18 +1,34 @@
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+const textareaVariants = cva(
+  "flex min-h-[80px] w-full resize-none text-foreground placeholder:text-neutral-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-neutral-500",
+  {
+    variants: {
+      variant: {
+        default:
+          "rounded-sm border border-neutral-200 bg-white px-3 py-2.5 text-body focus-visible:outline-none focus-visible:border-2 focus-visible:border-gold-500 focus-visible:px-[11px] focus-visible:py-[9px] disabled:bg-surface aria-[invalid=true]:border-danger-500 aria-[invalid=true]:bg-danger-50 dark:bg-neutral-800 dark:border-neutral-700",
+        underlined:
+          "rounded-t-sm rounded-b-none border-0 border-b border-b-neutral-400 bg-neutral-100 px-3 py-2.5 text-base outline-none focus-visible:border-b-2 focus-visible:border-b-gold-500 aria-[invalid=true]:border-b-2 aria-[invalid=true]:border-b-danger-500 aria-[invalid=true]:bg-danger-50 dark:border-b-neutral-600 dark:bg-neutral-800 dark:focus-visible:border-b-2 dark:focus-visible:border-b-gold-500 dark:aria-[invalid=true]:border-b-2 dark:aria-[invalid=true]:border-b-danger-500",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    VariantProps<typeof textareaVariants> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, variant, ...props }, ref) => {
     return (
       <textarea
-        className={cn(
-          "flex min-h-[80px] w-full rounded-sm border border-neutral-200 bg-white px-3 py-2.5 text-body text-foreground placeholder:text-neutral-500 focus-visible:outline-none focus-visible:border-2 focus-visible:border-gold-500 focus-visible:px-[11px] focus-visible:py-[9px] disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-surface aria-[invalid=true]:border-danger-500 aria-[invalid=true]:bg-danger-50 dark:bg-neutral-800 dark:border-neutral-700 dark:placeholder:text-neutral-500",
-          className,
-        )}
+        className={cn(textareaVariants({ variant }), className)}
         ref={ref}
         {...props}
       />
@@ -21,4 +37,4 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 );
 Textarea.displayName = "Textarea";
 
-export { Textarea };
+export { Textarea, textareaVariants };


### PR DESCRIPTION
## Summary

- Remove file upload / receipt field from the quick expense modal's "More options" section
- Increase notes textarea font size to 16px
- Connect the notes field to the transaction `description` property sent to the API
- Align the "Other" category dropdown style with the rest of the modal's inputs (bottom-border-only, filled background)

## Test plan

- [ ] Open the quick expense modal and expand "More options" — confirm the receipt upload button is gone and only the notes textarea remains
- [ ] Type in the notes field, submit an expense, and verify the `description` field is populated on the created transaction
- [ ] Select the "Other" category card — confirm the dropdown appears with a flat bottom-border style matching the recurrence frequency picker
- [ ] Verify dark mode renders correctly for all changed elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified form controls with an "underlined" appearance for dropdowns and textareas for a cleaner, consistent look.
* **Bug Fixes**
  * "Other" category dropdown now excludes categories already shown as quick choices, reducing duplicate options.
* **Layout**
  * Small spacing adjustment in the Notes area for improved alignment.
* **Accessibility**
  * Description field now exposes error state via standard accessibility attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->