### PR TITLE
fix: add Vercel SPA rewrite to serve index.html for all routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Without a vercel.json rewrite, hard-reloading a non-root URL (e.g.
/transactions, /dashboard) caused Vercel's static file server to return
404 before the SPA could load. Now all unmatched paths fall through to
index.html, letting React Router handle client-side routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to ensure proper application routing in production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mohammadrahmanian/Expense-tracker/pull/67)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->